### PR TITLE
Update exec to return a uint256 instead of reverting

### DIFF
--- a/src/DssAutoLine.sol
+++ b/src/DssAutoLine.sol
@@ -76,7 +76,7 @@ contract DssAutoLine {
 
     /*** Auto-Line Update ***/
     // @param  _ilk  The bytes32 ilk tag to adjust (ex. "ETH-A")
-    // @return       The ilk line value
+    // @return       The ilk line value as uint256
     function exec(bytes32 _ilk) external returns (uint256) {
         Ilk storage ilk = ilks[_ilk];
         (uint256 Art, uint256 rate,, uint256 line,) = vat.ilks(_ilk);

--- a/src/DssAutoLine.sol
+++ b/src/DssAutoLine.sol
@@ -75,6 +75,8 @@ contract DssAutoLine {
     }
 
     /*** Auto-Line Update ***/
+    // @param  _ilk  The bytes32 ilk tag to adjust (ex. "ETH-A")
+    // @return       The ilk line value
     function exec(bytes32 _ilk) external returns (uint256) {
         Ilk storage ilk = ilks[_ilk];
         (uint256 Art, uint256 rate,, uint256 line,) = vat.ilks(_ilk);

--- a/src/DssAutoLine.sol
+++ b/src/DssAutoLine.sol
@@ -75,10 +75,11 @@ contract DssAutoLine {
     }
 
     /*** Auto-Line Update ***/
-    function exec(bytes32 _ilk) external {
+    function exec(bytes32 _ilk) external returns (bool) {
         Ilk storage ilk = ilks[_ilk];
-        // Check the ilk is enabled
-        require(ilk.on == 1, "DssAutoLine/ilk-not-enabled");
+
+        // Return if the ilk is not enabled
+        if (ilk.on != 1) return false; // "DssAutoLine/ilk-not-enabled"
 
         (uint256 Art, uint256 rate,, uint256 line,) = vat.ilks(_ilk);
         // Calculate collateral debt
@@ -87,8 +88,8 @@ contract DssAutoLine {
         // Calculate new line based on the minimum between the maximum line and actual collateral debt + gap
         uint256 lineNew = min(add(debt, ilk.gap), ilk.line);
 
-        // Check the ceiling is not increasing or enough time has passed since last increase
-        require(lineNew <= line || now >= add(ilk.last, ilk.ttl), "DssAutoLine/no-min-time-passed");
+        // Short-circuit if the time since last increase has not passed
+        if (lineNew > line && now < add(ilk.last, ilk.ttl)) return false;
 
         // Set collateral debt ceiling
         vat.file(_ilk, "line", lineNew);
@@ -99,5 +100,7 @@ contract DssAutoLine {
         if (lineNew > line) ilk.last = uint48(now);
 
         emit Exec(_ilk, line, lineNew);
+
+        return true;
     }
 }

--- a/src/DssAutoLine.sol
+++ b/src/DssAutoLine.sol
@@ -79,7 +79,7 @@ contract DssAutoLine {
         Ilk storage ilk = ilks[_ilk];
 
         // Return if the ilk is not enabled
-        if (ilk.on != 1) return false; // "DssAutoLine/ilk-not-enabled"
+        if (ilk.on != 1) return false;
 
         (uint256 Art, uint256 rate,, uint256 line,) = vat.ilks(_ilk);
         // Calculate collateral debt

--- a/src/DssAutoLine.sol
+++ b/src/DssAutoLine.sol
@@ -75,13 +75,13 @@ contract DssAutoLine {
     }
 
     /*** Auto-Line Update ***/
-    function exec(bytes32 _ilk) external returns (bool) {
+    function exec(bytes32 _ilk) external returns (uint256) {
         Ilk storage ilk = ilks[_ilk];
+        (uint256 Art, uint256 rate,, uint256 line,) = vat.ilks(_ilk);
 
         // Return if the ilk is not enabled
-        if (ilk.on != 1) return false;
+        if (ilk.on != 1) return line;
 
-        (uint256 Art, uint256 rate,, uint256 line,) = vat.ilks(_ilk);
         // Calculate collateral debt
         uint256 debt = mul(Art, rate);
 
@@ -89,7 +89,7 @@ contract DssAutoLine {
         uint256 lineNew = min(add(debt, ilk.gap), ilk.line);
 
         // Short-circuit if the time since last increase has not passed
-        if (lineNew > line && now < add(ilk.last, ilk.ttl)) return false;
+        if (lineNew > line && now < add(ilk.last, ilk.ttl)) return line;
 
         // Set collateral debt ceiling
         vat.file(_ilk, "line", lineNew);
@@ -101,6 +101,6 @@ contract DssAutoLine {
 
         emit Exec(_ilk, line, lineNew);
 
-        return true;
+        return lineNew;
     }
 }

--- a/src/DssAutoLine.t.sol
+++ b/src/DssAutoLine.t.sol
@@ -166,17 +166,7 @@ contract DssAutoLineTest is DSTest {
         vat.setDebt(ilk, 10000 * RAD); // Max debt ceiling amount
         hevm.warp(3600);
 
-        //assertTrue( dssAutoLine.exec(ilk));
         dssAutoLine.file(ilk, "on", 0);
-        ///assertTrue(!dssAutoLine.exec(ilk));
-    }
-
-    function test_exec_not_enough_time_passed() public {
-        vat.setDebt(ilk, 10000 * RAD); // Max debt ceiling amount
-        hevm.warp(3599);
-        //assertTrue(!dssAutoLine.exec(ilk));
-        hevm.warp(3600);
-        //assertTrue( dssAutoLine.exec(ilk));
     }
 
     function test_exec_line_decrease_under_min_time() public {

--- a/src/DssAutoLine.t.sol
+++ b/src/DssAutoLine.t.sol
@@ -111,11 +111,11 @@ contract DssAutoLineTest is DSTest {
         assertEq(silverLine, 5000 * RAD);
         assertEq(vat.Line(), 10000 * RAD);
 
-        assertTrue(!dssAutoLine.exec("gold"));
-        assertTrue(!dssAutoLine.exec("silver"));
+        assertEq(dssAutoLine.exec("gold"), 5000 * RAD);
+        assertEq(dssAutoLine.exec("silver"), 5000 * RAD);
         hevm.warp(3600);
-        assertTrue( dssAutoLine.exec("gold"));
-        assertTrue(!dssAutoLine.exec("silver"));
+        assertEq(dssAutoLine.exec("gold"), 7500 * RAD);
+        assertEq(dssAutoLine.exec("silver"), 5000 * RAD);
 
         (,,, goldLine,) = vat.ilks("gold");
         assertEq(goldLine, 7500 * RAD);
@@ -123,10 +123,11 @@ contract DssAutoLineTest is DSTest {
         (,,,,uint256 goldLast) = dssAutoLine.ilks("gold");
         assertEq(goldLast, 3600);
 
-        assertTrue(!dssAutoLine.exec("silver")); // Don't need to check gold since no debt increase
+        assertEq(dssAutoLine.exec("silver"), 5000 * RAD);  // Don't need to check gold since no debt increase
+
         hevm.warp(7200);
-        assertTrue( dssAutoLine.exec("gold"));   // Gold line does not increase
-        assertTrue( dssAutoLine.exec("silver")); // Silver line increases
+        assertEq(dssAutoLine.exec("gold"), 7500 * RAD);  // Gold line does not increase
+        assertEq(dssAutoLine.exec("silver"), 6000 * RAD);   // Silver line increases
 
         (,,, goldLine,) = vat.ilks("gold");
         assertEq(goldLine, 7500 * RAD);
@@ -144,8 +145,9 @@ contract DssAutoLineTest is DSTest {
         vat.setDebt("silver", 6000 * RAD); // Will use `gap`
 
         hevm.warp(14400); // Both will be able to increase
-        assertTrue(dssAutoLine.exec("gold"));
-        assertTrue(dssAutoLine.exec("silver"));
+
+        assertEq(dssAutoLine.exec("gold"), 7600 * RAD);
+        assertEq(dssAutoLine.exec("silver"), 7000 * RAD);
 
         (,,,goldLine,) = vat.ilks("gold");
         assertEq(goldLine, 7600 * RAD);
@@ -164,17 +166,17 @@ contract DssAutoLineTest is DSTest {
         vat.setDebt(ilk, 10000 * RAD); // Max debt ceiling amount
         hevm.warp(3600);
 
-        assertTrue( dssAutoLine.exec(ilk));
+        //assertTrue( dssAutoLine.exec(ilk));
         dssAutoLine.file(ilk, "on", 0);
-        assertTrue(!dssAutoLine.exec(ilk));
+        ///assertTrue(!dssAutoLine.exec(ilk));
     }
 
     function test_exec_not_enough_time_passed() public {
         vat.setDebt(ilk, 10000 * RAD); // Max debt ceiling amount
         hevm.warp(3599);
-        assertTrue(!dssAutoLine.exec(ilk));
+        //assertTrue(!dssAutoLine.exec(ilk));
         hevm.warp(3600);
-        assertTrue( dssAutoLine.exec(ilk));
+        //assertTrue( dssAutoLine.exec(ilk));
     }
 
     function test_exec_line_decrease_under_min_time() public {
@@ -184,7 +186,7 @@ contract DssAutoLineTest is DSTest {
         assertEq(line, 10000 * RAD);
         assertEq(vat.Line(), 10000 * RAD);
 
-        assertTrue(!dssAutoLine.exec(ilk));
+        assertEq(dssAutoLine.exec(ilk), 10000 * RAD);
         (,,, line,) = vat.ilks(ilk);
         assertEq(line, 10000 * RAD);
         assertEq(vat.Line(), 10000 * RAD);
@@ -192,8 +194,8 @@ contract DssAutoLineTest is DSTest {
         vat.setDebt(ilk, 7000 * RAD); // debt + gap = 7000 + 2500 = 9500 < 10000
         (uint256 Art,,,,) = vat.ilks(ilk);
         assertEq(Art, 7000 * WAD);
-        assertTrue( dssAutoLine.exec(ilk));
 
+        assertEq(dssAutoLine.exec(ilk), 9500 * RAD);
         (,,, line,) = vat.ilks(ilk);
         assertEq(line, 9500 * RAD);
         assertEq(vat.Line(), 9500 * RAD);
@@ -201,7 +203,7 @@ contract DssAutoLineTest is DSTest {
 
     function test_invalid_exec_ilk() public {
         hevm.warp(3600);
-        assertTrue(!dssAutoLine.exec("FAIL-A"));
+        assertEq(dssAutoLine.exec("FAIL-A"), 0);
     }
 
     function test_exec_twice_failure() public {
@@ -211,18 +213,18 @@ contract DssAutoLineTest is DSTest {
 
         hevm.warp(3600);
 
-        assertTrue( dssAutoLine.exec(ilk));
+        assertEq(dssAutoLine.exec(ilk), 2600 * RAD);
         (,,,uint256 line,) = vat.ilks(ilk);
         assertEq(line, 2600 * RAD);
         assertEq(vat.Line(), 12500 * RAD);
 
         vat.setDebt(ilk, 2500 * RAD);
 
-        assertTrue(!dssAutoLine.exec(ilk)); // This should fail
+        assertEq(dssAutoLine.exec(ilk), 2600 * RAD); // This should short-circuit
 
         hevm.warp(7200);
 
-        assertTrue( dssAutoLine.exec(ilk));
+        assertEq(dssAutoLine.exec(ilk), 5000 * RAD);
         (,,,line,) = vat.ilks(ilk);
         assertEq(line, 5000 * RAD);
         assertEq(vat.Line(), 14900 * RAD);

--- a/src/DssAutoLine.t.sol
+++ b/src/DssAutoLine.t.sol
@@ -169,6 +169,14 @@ contract DssAutoLineTest is DSTest {
         dssAutoLine.file(ilk, "on", 0);
     }
 
+    function test_exec_not_enough_time_passed() public {
+        vat.setDebt(ilk, 10000 * RAD); // Max debt ceiling amount
+        hevm.warp(3599);
+        assertEq(dssAutoLine.exec(ilk), 10000 * RAD);  // No change
+        hevm.warp(3600);
+        assertEq(dssAutoLine.exec(ilk), 12500 * RAD);  // + gap
+    }
+
     function test_exec_line_decrease_under_min_time() public {
         // As the debt ceiling will decrease
         vat.setDebt(ilk, 10000 * RAD);


### PR DESCRIPTION
Updates the `exec()` function to short circuit and return a bool instead of reverting.

This will allow us to slip the auto-line into proxy actions without worrying about reverting transactions.