### PR TITLE
Simplified enable/disable of ilks

### DIFF
--- a/src/DssAutoLine.sol
+++ b/src/DssAutoLine.sol
@@ -59,7 +59,7 @@ contract DssAutoLine {
         @param gap    Amount of collateral to step [RAD]
         @param ttl    Minimum time between increase [seconds]
     */
-    function enableIlk(bytes32 ilk, uint256 line, uint256 gap, uint256 ttl) external auth {
+    function setIlk(bytes32 ilk, uint256 line, uint256 gap, uint256 ttl) external auth {
         require(ttl  < uint48(-1), "DssAutoLine/invalid-ttl");
         require(line > 0,          "DssAutoLine/invalid-line");
         ilks[ilk] = Ilk(line, gap, uint48(ttl), 0, 0);
@@ -70,7 +70,7 @@ contract DssAutoLine {
         @dev Disable and remove an ilk
         @param ilk    Collateral type
     */
-    function disableIlk(bytes32 ilk) external auth {
+    function remIlk(bytes32 ilk) external auth {
         delete ilks[ilk];
         emit Disable(ilk);
     }

--- a/src/DssAutoLine.sol
+++ b/src/DssAutoLine.sol
@@ -25,8 +25,8 @@ contract DssAutoLine {
     /*** Events ***/
     event Rely(address indexed usr);
     event Deny(address indexed usr);
-    event Enable(bytes32 indexed ilk, uint256 line, uint256 gap, uint256 ttl);
-    event Disable(bytes32 indexed ilk);
+    event Setup(bytes32 indexed ilk, uint256 line, uint256 gap, uint256 ttl);
+    event Remove(bytes32 indexed ilk);
     event Exec(bytes32 indexed ilk, uint256 line, uint256 lineNew);
 
     /*** Init ***/
@@ -54,7 +54,7 @@ contract DssAutoLine {
 
     /**
         @dev Add or update an ilk
-        @param ilk    Collateral type
+        @param ilk    Collateral type (ex. ETH-A)
         @param line   Collateral maximum debt ceiling that can be configured [RAD]
         @param gap    Amount of collateral to step [RAD]
         @param ttl    Minimum time between increase [seconds]
@@ -63,16 +63,16 @@ contract DssAutoLine {
         require(ttl  < uint48(-1), "DssAutoLine/invalid-ttl");
         require(line > 0,          "DssAutoLine/invalid-line");
         ilks[ilk] = Ilk(line, gap, uint48(ttl), 0, 0);
-        emit Enable(ilk, line, gap, ttl);
+        emit Setup(ilk, line, gap, ttl);
     }
 
     /**
-        @dev Disable and remove an ilk
-        @param ilk    Collateral type
+        @dev Remove an ilk
+        @param ilk    Collateral type (ex. ETH-A)
     */
     function remIlk(bytes32 ilk) external auth {
         delete ilks[ilk];
-        emit Disable(ilk);
+        emit Remove(ilk);
     }
 
     function rely(address usr) external auth {

--- a/src/DssAutoLine.sol
+++ b/src/DssAutoLine.sol
@@ -25,8 +25,8 @@ contract DssAutoLine {
     /*** Events ***/
     event Rely(address indexed usr);
     event Deny(address indexed usr);
-    event Enable(bytes32 ilk, uint256 line, uint256 gap, uint256 ttl);
-    event Disable(bytes32 ilk);
+    event Enable(bytes32 indexed ilk, uint256 line, uint256 gap, uint256 ttl);
+    event Disable(bytes32 indexed ilk);
     event Exec(bytes32 indexed ilk, uint256 line, uint256 lineNew);
 
     /*** Init ***/

--- a/src/DssAutoLine.sol
+++ b/src/DssAutoLine.sol
@@ -26,7 +26,8 @@ contract DssAutoLine {
     /*** Events ***/
     event Rely(address indexed usr);
     event Deny(address indexed usr);
-    event File(bytes32 indexed ilk, bytes32 indexed what, uint256 data);
+    event Enable(bytes32 ilk);
+    event Disable(bytes32 ilk);
     event Exec(bytes32 indexed ilk, uint256 line, uint256 lineNew);
 
     /*** Init ***/
@@ -51,13 +52,18 @@ contract DssAutoLine {
     }
 
     /*** Administration ***/
-    function file(bytes32 ilk, bytes32 what, uint256 data) external auth {
-        if      (what == "on")    ilks[ilk].on   = uint8(data);
-        else if (what == "ttl")   ilks[ilk].ttl  = uint48(data);
-        else if (what == "line")  ilks[ilk].line = uint256(data);
-        else if (what == "gap")   ilks[ilk].gap  = uint256(data);
-        else revert("DssAutoLine/file-unrecognized-param");
-        emit File(ilk, what, data);
+
+    // Add or update an ilk
+    function enableIlk(bytes32 ilk, uint256 line, uint256 gap, uint256 ttl) external auth {
+        require(ttl < uint48(-1), "DssAutoLine/invalid-ttl");
+        ilks[ilk] = Ilk(line, gap, 1, uint48(ttl), 0, 0);
+        emit Enable(ilk);
+    }
+
+    // Disable an ilk
+    function disableIlk(bytes32 ilk) external auth {
+        delete ilks[ilk];
+        emit Disable(ilk);
     }
 
     function rely(address usr) external auth {

--- a/src/DssAutoLine.sol
+++ b/src/DssAutoLine.sol
@@ -25,7 +25,7 @@ contract DssAutoLine {
     /*** Events ***/
     event Rely(address indexed usr);
     event Deny(address indexed usr);
-    event Enable(bytes32 ilk);
+    event Enable(bytes32 ilk, uint256 line, uint256 gap, uint256 ttl);
     event Disable(bytes32 ilk);
     event Exec(bytes32 indexed ilk, uint256 line, uint256 lineNew);
 
@@ -63,7 +63,7 @@ contract DssAutoLine {
         require(ttl < uint48(-1), "DssAutoLine/invalid-ttl");
         require(line > 0, "DssAutoLine/invalid-line");
         ilks[ilk] = Ilk(line, gap, uint48(ttl), 0, 0);
-        emit Enable(ilk);
+        emit Enable(ilk, line, gap, ttl);
     }
 
     /**

--- a/src/DssAutoLine.sol
+++ b/src/DssAutoLine.sol
@@ -53,14 +53,23 @@ contract DssAutoLine {
 
     /*** Administration ***/
 
-    // Add or update an ilk
+    /**
+        @dev Add or update an ilk
+        @param ilk    Collateral type
+        @param line   Collateral maximum debt ceiling that can be configured [RAD]
+        @param gap    Amount of collateral to step [RAD]
+        @param ttl    Minimum time between increase [seconds]
+    */
     function enableIlk(bytes32 ilk, uint256 line, uint256 gap, uint256 ttl) external auth {
         require(ttl < uint48(-1), "DssAutoLine/invalid-ttl");
         ilks[ilk] = Ilk(line, gap, 1, uint48(ttl), 0, 0);
         emit Enable(ilk);
     }
 
-    // Disable an ilk
+    /**
+        @dev Disable and remove an ilk
+        @param ilk    Collateral type
+    */
     function disableIlk(bytes32 ilk) external auth {
         delete ilks[ilk];
         emit Disable(ilk);

--- a/src/DssAutoLine.sol
+++ b/src/DssAutoLine.sol
@@ -60,8 +60,8 @@ contract DssAutoLine {
         @param ttl    Minimum time between increase [seconds]
     */
     function enableIlk(bytes32 ilk, uint256 line, uint256 gap, uint256 ttl) external auth {
-        require(ttl < uint48(-1), "DssAutoLine/invalid-ttl");
-        require(line > 0, "DssAutoLine/invalid-line");
+        require(ttl  < uint48(-1), "DssAutoLine/invalid-ttl");
+        require(line > 0,          "DssAutoLine/invalid-line");
         ilks[ilk] = Ilk(line, gap, uint48(ttl), 0, 0);
         emit Enable(ilk, line, gap, ttl);
     }

--- a/src/DssAutoLine.sol
+++ b/src/DssAutoLine.sol
@@ -94,7 +94,6 @@ contract DssAutoLine {
     // @param  _ilk  The bytes32 ilk tag to adjust (ex. "ETH-A")
     // @return       The ilk line value as uint256
     function exec(bytes32 _ilk) external returns (uint256) {
-
         (uint256 Art, uint256 rate,, uint256 line,) = vat.ilks(_ilk);
         uint256 ilkLine = ilks[_ilk].line;
 

--- a/src/DssAutoLine.t.sol
+++ b/src/DssAutoLine.t.sol
@@ -52,10 +52,7 @@ contract DssAutoLineTest is DSTest {
         vat.file(ilk, "rate", 1 * RAY);
         dssAutoLine = new DssAutoLine(address(vat));
 
-        dssAutoLine.file(ilk, "line", 12600 * RAD);
-        dssAutoLine.file(ilk, "ttl", 1 hours);
-        dssAutoLine.file(ilk, "gap", 2500 * RAD);
-        dssAutoLine.file(ilk, "on", 1);
+        dssAutoLine.enableIlk(ilk, 12600 * RAD, 2500 * RAD, 1 hours);
 
         hevm = Hevm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
         _warp(0);
@@ -97,15 +94,12 @@ contract DssAutoLineTest is DSTest {
 
     function test_exec_multiple_ilks() public {
         vat.file("gold",         "line", 5000 * RAD);
-        dssAutoLine.file("gold", "line", 7600 * RAD);
+        dssAutoLine.enableIlk("gold", 7600 * RAD, 2500 * RAD, 1 hours);
 
         vat.file("silver", "line", 5000 * RAD);
         vat.file("silver", "rate", 1 * RAY);
 
-        dssAutoLine.file("silver", "line", 7600 * RAD);
-        dssAutoLine.file("silver", "ttl", 2 hours);     // Different than gold
-        dssAutoLine.file("silver", "gap", 1000 * RAD);  // Different than gold
-        dssAutoLine.file("silver", "on", 1);
+        dssAutoLine.enableIlk("silver", 7600 * RAD, 1000 * RAD, 2 hours);
 
         vat.setDebt("gold", 5000 * RAD); // Max gold debt ceiling amount
         (uint256 goldArt,,, uint256 goldLine,) = vat.ilks("gold");
@@ -179,7 +173,8 @@ contract DssAutoLineTest is DSTest {
         vat.setDebt(ilk, 10000 * RAD); // Max debt ceiling amount
         _warp(1 hours);
 
-        dssAutoLine.file(ilk, "on", 0);
+        dssAutoLine.disableIlk(ilk);
+        assertEq(dssAutoLine.exec(ilk), 10000 * RAD); // The line from the vat
     }
 
     function test_exec_not_enough_time_passed() public {
@@ -255,7 +250,7 @@ contract DssAutoLineTest is DSTest {
     function test_exec_twice_failure() public {
         vat.setDebt(ilk, 100 * RAD); // Max debt ceiling amount
         vat.file(ilk,         "line", 100 * RAD);
-        dssAutoLine.file(ilk, "line", 20000 * RAD);
+        dssAutoLine.enableIlk(ilk, 20000 * RAD, 2500 * RAD, 1 hours);
 
         _warp(1 hours);
 

--- a/src/DssAutoLine.t.sol
+++ b/src/DssAutoLine.t.sol
@@ -76,7 +76,7 @@ contract DssAutoLineTest is DSTest {
         (,,,line,) = vat.ilks(ilk);
         assertEq(line, 12500 * RAD);
         assertEq(vat.Line(), 12500 * RAD);
-        (,,,, uint256 last, uint256 lastInc) = dssAutoLine.ilks(ilk);
+        (,,, uint256 last, uint256 lastInc) = dssAutoLine.ilks(ilk);
         assertEq(last   , 1 hours / 15);
         assertEq(lastInc, 1 hours);
         vat.setDebt(ilk, 10200 * RAD); // New max debt ceiling amount
@@ -87,7 +87,7 @@ contract DssAutoLineTest is DSTest {
         (,,,line,) = vat.ilks(ilk);
         assertEq(line, 12600 * RAD); // < 12700 * RAD (due max line: 10200 + gap)
         assertEq(vat.Line(), 12600 * RAD);
-        (,,,, last, lastInc) = dssAutoLine.ilks(ilk);
+        (,,, last, lastInc) = dssAutoLine.ilks(ilk);
         assertEq(last   , 2 hours / 15);
         assertEq(lastInc, 2 hours);
     }
@@ -122,7 +122,7 @@ contract DssAutoLineTest is DSTest {
         (,,, goldLine,) = vat.ilks("gold");
         assertEq(goldLine, 7500 * RAD);
         assertEq(vat.Line(), 12500 * RAD);
-        (,,,, uint256 goldLast, uint256 goldLastInc) = dssAutoLine.ilks("gold");
+        (,,, uint256 goldLast, uint256 goldLastInc) = dssAutoLine.ilks("gold");
         assertEq(goldLast   , 1 hours / 15);
         assertEq(goldLastInc, 1 hours);
 
@@ -139,10 +139,10 @@ contract DssAutoLineTest is DSTest {
         assertEq(vat.Line(), 13500 * RAD);
         assertTrue(vat.Line() == goldLine + silverLine);
 
-        (,,,, goldLast, goldLastInc) = dssAutoLine.ilks("gold");
+        (,,, goldLast, goldLastInc) = dssAutoLine.ilks("gold");
         assertEq(goldLast   , 1 hours / 15);
         assertEq(goldLastInc, 1 hours);
-        (,,,, uint256 silverLast, uint256 silverLastInc) = dssAutoLine.ilks("silver");
+        (,,, uint256 silverLast, uint256 silverLastInc) = dssAutoLine.ilks("silver");
         assertEq(silverLast   , 2 hours / 15);
         assertEq(silverLastInc, 2 hours);
 
@@ -161,10 +161,10 @@ contract DssAutoLineTest is DSTest {
         assertEq(vat.Line(), 14600 * RAD);
         assertTrue(vat.Line() == goldLine + silverLine);
 
-        (,,,, goldLast, goldLastInc) = dssAutoLine.ilks("gold");
+        (,,, goldLast, goldLastInc) = dssAutoLine.ilks("gold");
         assertEq(goldLast   , 4 hours / 15);
         assertEq(goldLastInc, 4 hours);
-        (,,,, silverLast, silverLastInc) = dssAutoLine.ilks("silver");
+        (,,, silverLast, silverLastInc) = dssAutoLine.ilks("silver");
         assertEq(silverLast   , 4 hours / 15);
         assertEq(silverLastInc, 4 hours);
     }
@@ -191,7 +191,7 @@ contract DssAutoLineTest is DSTest {
         (,,, uint256 line,) = vat.ilks(ilk);
         assertEq(line, 10000 * RAD);
         assertEq(vat.Line(), 10000 * RAD);
-        (,,,, uint256 last, uint256 lastInc) = dssAutoLine.ilks(ilk);
+        (,,, uint256 last, uint256 lastInc) = dssAutoLine.ilks(ilk);
         assertEq(last   , 0);
         assertEq(lastInc, 0);
 
@@ -201,7 +201,7 @@ contract DssAutoLineTest is DSTest {
         (,,, line,) = vat.ilks(ilk);
         assertEq(line, 10000 * RAD);
         assertEq(vat.Line(), 10000 * RAD);
-        (,,,, last, lastInc) = dssAutoLine.ilks(ilk);
+        (,,, last, lastInc) = dssAutoLine.ilks(ilk);
         assertEq(last   , 0); // no update
         assertEq(lastInc, 0); // no increment
 
@@ -215,7 +215,7 @@ contract DssAutoLineTest is DSTest {
         (,,, line,) = vat.ilks(ilk);
         assertEq(line, 9500 * RAD);
         assertEq(vat.Line(), 9500 * RAD);
-        (,,,, last, lastInc) = dssAutoLine.ilks(ilk);
+        (,,, last, lastInc) = dssAutoLine.ilks(ilk);
         assertEq(last   , 2); // update
         assertEq(lastInc, 0); // no increment
 
@@ -227,7 +227,7 @@ contract DssAutoLineTest is DSTest {
         (,,, line,) = vat.ilks(ilk);
         assertEq(line, 9500 * RAD);
         assertEq(vat.Line(), 9500 * RAD);
-        (,,,, last, lastInc) = dssAutoLine.ilks(ilk);
+        (,,, last, lastInc) = dssAutoLine.ilks(ilk);
         assertEq(last   , 2); // no update
         assertEq(lastInc, 0); // no increment
 
@@ -237,7 +237,7 @@ contract DssAutoLineTest is DSTest {
         (,,, line,) = vat.ilks(ilk);
         assertEq(line, 8500 * RAD);
         assertEq(vat.Line(), 8500 * RAD);
-        (,,,, last, lastInc) = dssAutoLine.ilks(ilk);
+        (,,, last, lastInc) = dssAutoLine.ilks(ilk);
         assertEq(last   , 3); // update
         assertEq(lastInc, 0); // no increment
     }

--- a/src/DssAutoLine.t.sol
+++ b/src/DssAutoLine.t.sol
@@ -52,7 +52,7 @@ contract DssAutoLineTest is DSTest {
         vat.file(ilk, "rate", 1 * RAY);
         dssAutoLine = new DssAutoLine(address(vat));
 
-        dssAutoLine.enableIlk(ilk, 12600 * RAD, 2500 * RAD, 1 hours);
+        dssAutoLine.setIlk(ilk, 12600 * RAD, 2500 * RAD, 1 hours);
 
         hevm = Hevm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
         _warp(0);
@@ -94,12 +94,12 @@ contract DssAutoLineTest is DSTest {
 
     function test_exec_multiple_ilks() public {
         vat.file("gold",         "line", 5000 * RAD);
-        dssAutoLine.enableIlk("gold", 7600 * RAD, 2500 * RAD, 1 hours);
+        dssAutoLine.setIlk("gold", 7600 * RAD, 2500 * RAD, 1 hours);
 
         vat.file("silver", "line", 5000 * RAD);
         vat.file("silver", "rate", 1 * RAY);
 
-        dssAutoLine.enableIlk("silver", 7600 * RAD, 1000 * RAD, 2 hours);
+        dssAutoLine.setIlk("silver", 7600 * RAD, 1000 * RAD, 2 hours);
 
         vat.setDebt("gold", 5000 * RAD); // Max gold debt ceiling amount
         (uint256 goldArt,,, uint256 goldLine,) = vat.ilks("gold");
@@ -173,7 +173,7 @@ contract DssAutoLineTest is DSTest {
         vat.setDebt(ilk, 10000 * RAD); // Max debt ceiling amount
         _warp(1 hours);
 
-        dssAutoLine.disableIlk(ilk);
+        dssAutoLine.remIlk(ilk);
         assertEq(dssAutoLine.exec(ilk), 10000 * RAD); // The line from the vat
     }
 
@@ -250,7 +250,7 @@ contract DssAutoLineTest is DSTest {
     function test_exec_twice_failure() public {
         vat.setDebt(ilk, 100 * RAD); // Max debt ceiling amount
         vat.file(ilk,         "line", 100 * RAD);
-        dssAutoLine.enableIlk(ilk, 20000 * RAD, 2500 * RAD, 1 hours);
+        dssAutoLine.setIlk(ilk, 20000 * RAD, 2500 * RAD, 1 hours);
 
         _warp(1 hours);
 


### PR DESCRIPTION
Simplifies the process of adding/updating/removing ilks. Removes the `file` function.

Addition of an ilk required four external `file` calls, this replaces additions and updates with an `enableIlk(bytes32 ilk, uint256 line, uint256 gap, uint256 ttl)` function. 

* To add an ilk, call `enableIlk("ETH-A", 500 * MILLION * RAD, 10 * MILLION * RAD, 1 hours)`
* To update an ilk, call `enableIlk("ETH-A", 800 * MILLION * RAD, 10 * MILLION * RAD, 1 hours)`
  (requiring explicitness here will increase auditability in executives)
* To remove or disable an ilk, call `disableIlk("ETH-A")`

Open to alternative name ideas for functions/events